### PR TITLE
Fix trailing line for package.el compatibility

### DIFF
--- a/scratch-palette.el
+++ b/scratch-palette.el
@@ -112,4 +112,4 @@
 
 (provide 'scratch-palette)
 
-;; scratch-palette.el ends here
+;;; scratch-palette.el ends here


### PR DESCRIPTION
Three semicolons are required for `package-buffer-info` to correctly parse the file.

P.S. I'm adding a [MELPA](http://melpa.milkbox.net) recipe for this library.
